### PR TITLE
Adding model helper to source code to return related ContentType Alias

### DIFF
--- a/src/Limbo.Umbraco.ModelsBuilder/Services/ModelsSourceGenerator.cs
+++ b/src/Limbo.Umbraco.ModelsBuilder/Services/ModelsSourceGenerator.cs
@@ -404,8 +404,15 @@ namespace Limbo.Umbraco.ModelsBuilder.Services {
             writer.WriteLine($"    public partial class {model.ClrName}{(inherits.Any() ? " : " + string.Join(", ", inherits) : "")} {{");
             writer.WriteLine();
 
+            //Adding Model Helpers
+            writer.WriteLine($"//Helpers");
+            writer.WriteLine($"#pragma warning disable 0109 // new is redundant");
+            writer.WriteLine();
+            writer.WriteLine($"public new const string ModelTypeAlias = \"{model.Alias}\";");
+            writer.WriteLine();
+            writer.WriteLine($"#pragma warning restore 0109");
         }
-        
+
         /// <summary>
         /// Internal method used for writing the class close declaration to the file.
         /// </summary>


### PR DESCRIPTION
This adds a constant to each generated model that provides the string Content Type alias so that "magic strings" can be avoided in various code applications

example usage:

`posts = blog.DescendantsOrSelf(BlogPost.ModelTypeAlias);`

instead of:

`posts = blog.DescendantsOrSelf("blogPost");`