### PR TITLE
Add standard Helper methods to Content Models

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Coming soon. Meanwhile, have a look at the following sections in this README fil
 
 - [Configuration](#configuration)
 - [Events](#events)
-- [Notifcations](#notifcations)
+- [Notifications](#notifications)
+- [Usage Tips](#usage)
 
 ## Configuration
 
@@ -183,7 +184,7 @@ namespace UmbracoNineTests.ModelsBuilder {
 }
 ```
 
-## Notifcations
+## Notifications
 
 ### GetDefaultSettingsNotification
 
@@ -270,4 +271,56 @@ namespace UmbracoNineTests.ModelsBuilder {
     }
 
 }
+```
+## Usage
+
+### Strongly-Type All the Things
+
+Using the generated models, not only can you access the property data in a strongly-typed fashion, but you can also access information about the Content Type and Properties - no more magic strings!
+
+Some examples:
+
+`MyContentType.ModelTypeAlias` returns the string representation of the Content Type's alias. This can help in code where you are checking the type of an IPublishedContent:
+
+```csharp
+if(currentPage.ContentType.Alias == MyContentType.ModelTypeAlias)
+{
+	//Do stuff ...
+}
+else if(currentPage.ContentType.Alias == MyOtherType.ModelTypeAlias)
+{
+	//Do something else ...
+}
+else 
+{
+	//No match, it is some other Content Type
+}
+```
+
+If you want more than just the alias, use `MyContentType.GetModelContentType()` which returns an `IPublishedContentType`:
+
+```csharp
+
+@using Umbraco.Cms.Core.PublishedCache;
+@inject IPublishedSnapshotAccessor  PublishedSnapshotAccessor 
+
+...
+
+var theDocType = MyContentType.GetModelContentType(PublishedSnapshotAccessor);
+var publishedItemType = theDocType.ItemType;
+```
+
+`MyContentType.GetModelPropertyType()` returns an `IPublishedPropertyType` for a specified property from the Content Type. Once you have the property, you can get its string alias or other information about the property:
+
+```csharp
+
+@using Umbraco.Cms.Core.PublishedCache;
+@inject IPublishedSnapshotAccessor  PublishedSnapshotAccessor 
+
+...
+
+var theProperty = MyContentType.GetModelPropertyType(PublishedSnapshotAccessor, n=> n.MySpecialProperty);
+
+var propAlias = theProperty.Alias;
+var propEditor = theProperty.EditorAlias;
 ```


### PR DESCRIPTION
Adds some helper methods which are available in the Embedded (and in OMB) version. See readme updates for details.